### PR TITLE
Fixed fractal watch not updating views on file change

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -23,3 +23,4 @@ fractal.docs.set("path", __dirname + "/resources/styles/docs");
 fractal.web.set("builder.dest", __dirname + "/web/pattern-library");
 fractal.web.set('builder.static.ignored', __dirname + "/web/pattern-library");
 fractal.web.set("static.path", __dirname + "/web");
+fractal.web.set('server.watch', true);


### PR DESCRIPTION
Thought I was crazy when views or docs weren't updating on file changes. Discovered fractal doesn't trigger rebuilds on file change by default.

https://fractal.build/guide/web/configuration-reference.html#server-watch

This change fixed the issue with having to manually run a rebuild every time a change was made. 