### PR TITLE
messaging icon positioning

### DIFF
--- a/resources/styles/_base.scss
+++ b/resources/styles/_base.scss
@@ -15,9 +15,9 @@ html {
 
 body {
     color: $plain-text;
-    font-family: $font-stack;
-    font-size: $base-font-size;
-    line-height: $base-line-height;
+    font-family: $body-font-stack;
+    font-size: $body-font-size;
+    line-height: $body-line-height;
     margin: 0;
 }
 
@@ -157,7 +157,7 @@ textarea {
     box-sizing: border-box;
     color: $plain-text;
     display: block;
-    font-family: $font-stack;
+    font-family: $body-font-stack;
     margin: 0;
     padding: 0.4rem 0.6rem;
     width: 100%;

--- a/resources/styles/_base.scss
+++ b/resources/styles/_base.scss
@@ -16,7 +16,8 @@ html {
 body {
     color: $plain-text;
     font-family: $font-stack;
-    line-height: 1.5;
+    font-size: $base-font-size;
+    line-height: $base-line-height;
     margin: 0;
 }
 

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -7,11 +7,12 @@ $gutter: 30px !default;
 $columns: 12 !default;
 
 ///
-/// This is the default font stack.
+/// Default font stack, size, line-height
 ///
 
 $font-stack: Arial, sans-serif !default;
-
+$base-font-size: 1rem;
+$base-line-height: 1.5;
 
 ///
 /// Color Scales

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -10,9 +10,9 @@ $columns: 12 !default;
 /// Default font stack, size, line-height
 ///
 
-$font-stack: Arial, sans-serif !default;
-$base-font-size: 1rem;
-$base-line-height: 1.5;
+$body-font-stack: Arial, sans-serif !default;
+$body-font-size: 1rem;
+$body-line-height: 1.5;
 
 ///
 /// Color Scales

--- a/resources/styles/docs/reference/fonts.md
+++ b/resources/styles/docs/reference/fonts.md
@@ -1,5 +1,5 @@
 ```
-$font-stack: Arial, sans-serif !default;
+$body-font-stack: Arial, sans-serif !default;
 ```
 
 The default font stack. This is mainly helpful for elements that don't inherit fonts properly (like inputs.)

--- a/resources/styles/molecules/messaging/README.md
+++ b/resources/styles/molecules/messaging/README.md
@@ -1,4 +1,6 @@
-Messaging is typically used for messages from the server - info boxes, warnings, alerts, validation errors, etc.
+Messaging is typically used for messages from the server - warnings, errors on form validation, site outage info, etc. An optional SVG-based icon is often used within messaging. We modify the icon's vertical position to align to the top of its adjacent `.messaging__content`, accounting for messaging's line-height. This allows for the icon to appear aligned to the cap height of  `.messaging__content`'a text, not to the top of `.messaging__content` bounding box.
+
+It's recommended to stick with `rem` units for messaging's `$font-size` and `$icon-size` mixin arguments.
 
 ### Sass Mixin
 
@@ -11,5 +13,5 @@ None.
 ### Emmet Shorthand
 
 ```
-.accordion>div>(.header{header}+.content>{lorem ipsum})
+.messaging>.messaging__icon>svg^.messaging__content>{lorem ipsum}
 ```

--- a/resources/styles/molecules/messaging/messaging--filled.twig
+++ b/resources/styles/molecules/messaging/messaging--filled.twig
@@ -1,35 +1,33 @@
 <div class="messaging -filled">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path d="M3 20l1.3 -3.9a9 8 0 1 1 3.4 2.9l-4.7 1" />
         <line x1="12" y1="12" x2="12" y2="12.01" />
         <line x1="8" y1="12" x2="8" y2="12.01" />
         <line x1="16" y1="12" x2="16" y2="12.01" />
     </svg>
-    <p class="messaging__content">
-        <strong>Default</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Default</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>
 
 <div class="messaging -filled -success">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="9" />
         <path d="M9 12l2 2l4 -4" />
     </svg>
-    <p class="messaging__content">
-        <strong>Success</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Success</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>
 
 <div class="messaging -filled -error">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path d="M8.7 3h6.6c.3 0 .5 .1 .7 .3l4.7 4.7c.2 .2 .3 .4 .3 .7v6.6c0 .3 -.1 .5 -.3 .7l-4.7 4.7c-.2 .2 -.4 .3 -.7 .3h-6.6c-.3 0 -.5 -.1 -.7 -.3l-4.7 -4.7c-.2 -.2 -.3 -.4 -.3 -.7v-6.6c0 -.3 .1 -.5 .3 -.7l4.7 -4.7c.2 -.2 .4 -.3 .7 -.3z" />
         <line x1="12" y1="8" x2="12" y2="12" />
         <line x1="12" y1="16" x2="12.01" y2="16" />
     </svg>
     <div class="messaging__content">
-        <p>
-            <strong>Error</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-        </p>
+        <p><strong>Error</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
         <ul>
             <li>Error one</li>
             <li>Error two</li>
@@ -38,22 +36,22 @@
 </div>
 
 <div class="messaging -filled -info">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="9" />
         <line x1="12" y1="8" x2="12.01" y2="8" />
         <polyline points="11 12 12 12 12 16 13 16" />
     </svg>
-    <p class="messaging__content">
-        <strong>Info</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Info</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>
 
 <div class="messaging -filled -warning">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path d="M12 9v2m0 4v.01" />
         <path d="M5 19h14a2 2 0 0 0 1.84 -2.75l-7.1 -12.25a2 2 0 0 0 -3.5 0l-7.1 12.25a2 2 0 0 0 1.75 2.75" />
     </svg>
-    <p class="messaging__content">
-        <strong>Warning</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Warning</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>

--- a/resources/styles/molecules/messaging/messaging.scss
+++ b/resources/styles/molecules/messaging/messaging.scss
@@ -12,19 +12,30 @@
 ///
 @mixin messaging (
     $color: $info,
+    $font-size: $base-font-size,
+    $icon-size: 1.5rem,
+    $line-height: $base-line-height,
     $link-color: inherit,
     $link-hover-color: inherit
 ) {
     $b: &;
 
+    $leading: $font-size * $line-height;
+
     background-color: $gray-100;
     box-shadow: .25rem 0 0 inset, $med-shadow;
+    font-size: $font-size;
+    line-height: $line-height;
     margin-bottom: 2rem;
     padding: 1rem 1.618rem;
     display: flex;
 
     &__icon {
+        height: $icon-size;
+        flex-shrink: 0;
         margin-right: 1.618rem;
+        transform: translateY(($leading - $icon-size) / 2);
+        width: $icon-size;
     }
 
     &__content {

--- a/resources/styles/molecules/messaging/messaging.scss
+++ b/resources/styles/molecules/messaging/messaging.scss
@@ -1,10 +1,8 @@
 ///
 /// For messages to the user.
 ///
-/// @character
-///     Font awesome character to show.
 /// @color
-///     Dominant color.
+///     Icon color.
 /// @link-color
 ///     Optionally override the default link color.
 /// @link-hover-color
@@ -12,9 +10,9 @@
 ///
 @mixin messaging (
     $color: $info,
-    $font-size: $base-font-size,
+    $font-size: $body-font-size,
     $icon-size: 1.5rem,
-    $line-height: $base-line-height,
+    $line-height: $body-line-height,
     $link-color: inherit,
     $link-hover-color: inherit
 ) {
@@ -34,8 +32,10 @@
         height: $icon-size;
         flex-shrink: 0;
         margin-right: 1.618rem;
-        transform: translateY(($leading - $icon-size) / 2);
         width: $icon-size;
+        @if $leading != $icon-size {
+            transform: translateY(($leading - $icon-size) / 2);
+        }
     }
 
     &__content {

--- a/resources/styles/molecules/messaging/messaging.twig
+++ b/resources/styles/molecules/messaging/messaging.twig
@@ -5,9 +5,9 @@
         <line x1="8" y1="12" x2="8" y2="12.01" />
         <line x1="16" y1="12" x2="16" y2="12.01" />
     </svg>
-    <p class="messaging__content">
-        <strong>Default</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Default</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>
 
 <div class="messaging -success">
@@ -15,9 +15,9 @@
         <circle cx="12" cy="12" r="9" />
         <path d="M9 12l2 2l4 -4" />
     </svg>
-    <p class="messaging__content">
-        <strong>Success</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Success</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>
 
 <div class="messaging -error">
@@ -27,9 +27,7 @@
         <line x1="12" y1="16" x2="12.01" y2="16" />
     </svg>
     <div class="messaging__content">
-        <p>
-            <strong>Error</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-        </p>
+        <p><strong>Error</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
         <ul>
             <li>Error one</li>
             <li>Error two</li>
@@ -43,9 +41,9 @@
         <line x1="12" y1="8" x2="12.01" y2="8" />
         <polyline points="11 12 12 12 12 16 13 16" />
     </svg>
-    <p class="messaging__content">
-        <strong>Info</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Info</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>
 
 <div class="messaging -warning">
@@ -53,7 +51,7 @@
         <path d="M12 9v2m0 4v.01" />
         <path d="M5 19h14a2 2 0 0 0 1.84 -2.75l-7.1 -12.25a2 2 0 0 0 -3.5 0l-7.1 12.25a2 2 0 0 0 1.75 2.75" />
     </svg>
-    <p class="messaging__content">
-        <strong>Warning</strong> – Message with a <a href="https://www.imarc.com/">link</a>.
-    </p>
+    <div class="messaging__content">
+        <p><strong>Warning</strong> – Message with a <a href="https://www.imarc.com/">link</a>.</p>
+    </div>
 </div>

--- a/resources/styles/molecules/messaging/messaging.twig
+++ b/resources/styles/molecules/messaging/messaging.twig
@@ -1,5 +1,5 @@
 <div class="messaging">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path d="M3 20l1.3 -3.9a9 8 0 1 1 3.4 2.9l-4.7 1" />
         <line x1="12" y1="12" x2="12" y2="12.01" />
         <line x1="8" y1="12" x2="8" y2="12.01" />
@@ -11,7 +11,7 @@
 </div>
 
 <div class="messaging -success">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="9" />
         <path d="M9 12l2 2l4 -4" />
     </svg>
@@ -21,7 +21,7 @@
 </div>
 
 <div class="messaging -error">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path d="M8.7 3h6.6c.3 0 .5 .1 .7 .3l4.7 4.7c.2 .2 .3 .4 .3 .7v6.6c0 .3 -.1 .5 -.3 .7l-4.7 4.7c-.2 .2 -.4 .3 -.7 .3h-6.6c-.3 0 -.5 -.1 -.7 -.3l-4.7 -4.7c-.2 -.2 -.3 -.4 -.3 -.7v-6.6c0 -.3 .1 -.5 .3 -.7l4.7 -4.7c.2 -.2 .4 -.3 .7 -.3z" />
         <line x1="12" y1="8" x2="12" y2="12" />
         <line x1="12" y1="16" x2="12.01" y2="16" />
@@ -38,7 +38,7 @@
 </div>
 
 <div class="messaging -info">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="9" />
         <line x1="12" y1="8" x2="12.01" y2="8" />
         <polyline points="11 12 12 12 12 16 13 16" />
@@ -49,7 +49,7 @@
 </div>
 
 <div class="messaging -warning">
-    <svg class="messaging__icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="messaging__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path d="M12 9v2m0 4v.01" />
         <path d="M5 19h14a2 2 0 0 0 1.84 -2.75l-7.1 -12.25a2 2 0 0 0 -3.5 0l-7.1 12.25a2 2 0 0 0 1.75 2.75" />
     </svg>


### PR DESCRIPTION
Our messaging component's icon positioning is not ideal. It does not adapt to changes in font-size and line-height, and will look off on projects that require these variances.

The attached video shows the issues and this PR's fix:
- 0:03 a project w/ smaller font-size, line-height (14px / 1.25) creates icon positioning issue
- 0:10 a project w/ larger font-size, line-height (18px / 1.85) creates icon positioning issue
- 0:12 extra copy shrinks the icon
- 0:19-end – I show how my PR fixes these issues

https://user-images.githubusercontent.com/2116946/110367540-cbfdab80-8015-11eb-8a97-9b902fe6027f.mp4

This introduces a `$base-font-size` and `$base-line-height` variable that are good additions to have in order to promote continuity for other component work in the future. I also removed the width and height attributes from the inline'd SVG code as it's unnecessary – we can control in CSS.

