### PR TITLE
Unified Padding

### DIFF
--- a/resources/styles/_base.scss
+++ b/resources/styles/_base.scss
@@ -215,7 +215,7 @@ table {
     }
     td,
     th {
-        padding: 0.5em 1em;
+        padding: $thin-padding;
         text-align: left;
         vertical-align: top;
     }

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -15,7 +15,7 @@ $body-font-size: 1rem;
 $body-line-height: 1.5;
 
 ///
-/// Default padding. Used for components like buttons, cards, and primary nav items.
+/// Regular padding. Used for components like buttons, cards, and primary nav items.
 ///
 
 $v-space: 1em;

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -15,6 +15,22 @@ $body-font-size: 1rem;
 $body-line-height: 1.5;
 
 ///
+/// Default padding. Used for components like buttons, cards, and primary nav items.
+///
+
+$v-space: 1em;
+$h-space: 1.618em;
+$padding: $v-space $h-space;
+
+///
+/// Thin padding. Used for components like breadcrumbs, radios, and within dropdowns.
+///
+
+$thin-v-space: .618em;
+$thin-h-space: 1em;
+$thin-padding: $thin-v-space $thin-h-space;
+
+///
 /// Color Scales
 ///
 @use 'colors' as *;

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -18,16 +18,16 @@ $body-line-height: 1.5;
 /// Regular padding. Used for components like buttons, cards, and primary nav items.
 ///
 
-$v-space: 1em;
-$h-space: 1.618em;
+$v-space: 1rem;
+$h-space: 1.5rem;
 $padding: $v-space $h-space;
 
 ///
 /// Thin padding. Used for components like breadcrumbs, radios, and within dropdowns.
 ///
 
-$thin-v-space: .618em;
-$thin-h-space: 1em;
+$thin-v-space: .5rem;
+$thin-h-space: 1rem;
 $thin-padding: $thin-v-space $thin-h-space;
 
 ///

--- a/resources/styles/atoms/avatar/avatar.scss
+++ b/resources/styles/atoms/avatar/avatar.scss
@@ -8,11 +8,11 @@
     text-align: center;
 
     &__info {
-        padding: 1rem;
+        padding: $thin-padding;
     }
 
     &__name {
-        margin: 1rem 0 .25rem;
+        margin-bottom: .25rem;
         font-size: 1.25rem;
         font-weight: bold;
     }

--- a/resources/styles/atoms/breadcrumbs/breadcrumbs.scss
+++ b/resources/styles/atoms/breadcrumbs/breadcrumbs.scss
@@ -10,6 +10,8 @@
     $color: $meta-text,
     $hover-color: $link-hover,
 ) {
+    $b: &;
+
     &__list {
         display: flex;
         list-style: none;
@@ -24,7 +26,11 @@
     &__link {
         color: $color;
         display: block;
-        padding: .618em .809em;
+        padding: $thin-v-space #{$thin-h-space/2};
+
+        #{$b}__item:first-child & {
+            margin-left: -#{$thin-h-space/2};
+        }
 
         &:hover {
             color: $hover-color;

--- a/resources/styles/atoms/button/button.scss
+++ b/resources/styles/atoms/button/button.scss
@@ -21,7 +21,7 @@
     cursor: pointer;
     display: inline-block;
     font-family: inherit;
-    padding: .618 1.618em;
+    padding: $padding;
     text-align: center;
     transition: box-shadow $fast $fade-easing,
         background-color $fast $fade-easing,

--- a/resources/styles/atoms/dropdown/dropdown.scss
+++ b/resources/styles/atoms/dropdown/dropdown.scss
@@ -3,7 +3,7 @@
 
     &__link {
         display: inline-block;
-        padding: .5rem 1rem;
+        padding: $thin-padding;
     }
 
     &__button {

--- a/resources/styles/atoms/menu/menu.scss
+++ b/resources/styles/atoms/menu/menu.scss
@@ -13,7 +13,7 @@
     &__link {
         margin-bottom: 0;
         display: block;
-        padding: .5rem 1rem;
+        padding: $thin-padding;
 
         &:hover {
             background-color: $blue-100;

--- a/resources/styles/atoms/pagination/pagination.scss
+++ b/resources/styles/atoms/pagination/pagination.scss
@@ -38,7 +38,7 @@
         color: $text-color;
         display: block;
         font-weight: bold;
-        padding: 0.618rem 1rem;
+        padding: $thin-padding;
         position: relative;
         transition: background-color $fast $fade-easing,
             color $fast $fade-easing;

--- a/resources/styles/atoms/progress/progress.scss
+++ b/resources/styles/atoms/progress/progress.scss
@@ -8,18 +8,18 @@
         position: relative;
 
         &::before {
-            border-left: .5rem solid $blue-300;
-            bottom: 1rem;
+            border-left: .5em solid $blue-300;
+            bottom: 1em;
             content: '';
-            left: .75rem;
+            left: .75em;
             position: absolute;
-            top: 1rem;
+            top: 1em;
             z-index: -1;
         }
     }
 
     &__item {
-        margin-bottom: 1rem;
+        margin-bottom: 1em;
     }
 
     &__link {
@@ -42,11 +42,11 @@
 
     &__icon {
         background-color: $blue-300;
-        border-radius: 2rem;
+        border-radius: 2em;
         color: $white;
         height: 2em;
-        margin-right: 1rem;
-        padding: .25rem;
+        margin-right: $thin-h-space;
+        padding: .25em;
         transition: transform $fade-easing $fast;
         vertical-align: middle;
         width: 2em;
@@ -69,16 +69,16 @@
             align-items: center;
             display: flex;
             flex-flow: column nowrap;
-            padding: 1rem;
+            padding: $padding;
             position: relative;
 
             &::before {
                 content: '';
-                border-top: .5rem solid $blue-300;
+                border-top: .5em solid $blue-300;
                 position: absolute;
                 left: 0;
                 right: 0;
-                top: 1.75rem;
+                top: #{$v-space + .75em};
                 z-index: -1;
 
                 .progress__item:first-child & {
@@ -94,7 +94,7 @@
 
         &__icon {
             margin-right: 0;
-            margin-bottom: 1rem;
+            margin-bottom: $v-space;
         }
     }
 }

--- a/resources/styles/atoms/progress/progress.scss
+++ b/resources/styles/atoms/progress/progress.scss
@@ -78,7 +78,7 @@
                 position: absolute;
                 left: 0;
                 right: 0;
-                top: #{$v-space + .75em};
+                top: #{$v-space + .75rem};
                 z-index: -1;
 
                 .progress__item:first-child & {

--- a/resources/styles/atoms/progress/progress.twig
+++ b/resources/styles/atoms/progress/progress.twig
@@ -1,7 +1,7 @@
 <nav class="progress">
     <ul class="progress__list">
         <li class="progress__item">
-            <a class="progress__link -complete link" href="#">
+            <a class="progress__link -complete" href="#">
                 <svg class="progress__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none">
                   <circle cx="9" cy="19" r="2" />
                   <circle cx="17" cy="19" r="2" />
@@ -11,7 +11,7 @@
             </a>
         </li>
         <li class="progress__item">
-            <a class="progress__link -complete link" href="#">
+            <a class="progress__link -complete" href="#">
                 <svg class="progress__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none">
                   <circle cx="9" cy="19" r="2" />
                   <circle cx="17" cy="19" r="2" />
@@ -21,7 +21,7 @@
             </a>
         </li>
         <li class="progress__item">
-            <a class="progress__link -active link" href="#">
+            <a class="progress__link -active" href="#">
                 <svg class="progress__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none">
                   <circle cx="9" cy="19" r="2" />
                   <circle cx="17" cy="19" r="2" />
@@ -31,7 +31,7 @@
             </a>
         </li>
         <li class="progress__item">
-            <a class="progress__link link" href="#">
+            <a class="progress__link" href="#">
                 <svg class="progress__icon" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none">
                   <circle cx="9" cy="19" r="2" />
                   <circle cx="17" cy="19" r="2" />

--- a/resources/styles/atoms/toggle-button/toggle-button.scss
+++ b/resources/styles/atoms/toggle-button/toggle-button.scss
@@ -25,7 +25,7 @@
     &__label {
         display: block;
         user-select: none;
-        padding: 0.618em 1em 0.618em .618em;
+        padding: $thin-padding;
     }
 
     &__checkbox {
@@ -78,10 +78,6 @@
 
     &.-blank {
         border: 2px solid $color;
-
-        #{$b}__label {
-            padding-left: 1em;
-        }
 
         #{$b}.-checked #{$b}__label,
         #{$b}__input:checked ~ #{$b}__label {

--- a/resources/styles/docs/reference/padding.md
+++ b/resources/styles/docs/reference/padding.md
@@ -1,0 +1,15 @@
+Boilerplate provides two prebuilt levels of padding.
+
+```
+$v-space: 1em;
+$h-space: 1.618em;
+$padding: $v-space $h-space;
+
+$thin-v-space: .618em;
+$thin-h-space: 1em;
+$thin-padding: $thin-v-space $thin-h-space;
+```
+
+Regular padding is used in places such as buttons, cards, primary nav items; places where the padding is separating content from the outer edge of a component or another component.
+
+Thin padding is used in places such as breadcrumbs, radios, and within dropdowns; places where the padding is separating content from other content in the same component.

--- a/resources/styles/docs/reference/padding.md
+++ b/resources/styles/docs/reference/padding.md
@@ -10,6 +10,6 @@ $thin-h-space: 1em;
 $thin-padding: $thin-v-space $thin-h-space;
 ```
 
-Regular padding is used in places such as buttons, cards, primary nav items; places where the padding is separating content from the outer edge of a component or another component.
+Regular padding is generally the 'outer padding' for components. It's used in places such as buttons, cards, and primary nav items; places where the padding is separating content from the outer edge of a component or another component.
 
-Thin padding is used in places such as breadcrumbs, radios, and within dropdowns; places where the padding is separating content from other content in the same component.
+Thin padding is generally the 'inner padding' for component elements. It's used in places such as breadcrumbs, radios, and within dropdowns; places where the padding is separating content from other content in the same component.

--- a/resources/styles/molecules/accordion/accordion.scss
+++ b/resources/styles/molecules/accordion/accordion.scss
@@ -17,7 +17,7 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: .618rem 1rem;
+        padding: $thin-padding;
     }
 
     &__heading {
@@ -26,7 +26,7 @@
 
     &__content {
         border-top: 1px solid $gray-100;
-        padding: .618rem 0;
+        padding: $thin-v-space 0;
         margin: 0 1rem;
     }
 

--- a/resources/styles/molecules/card/card.scss
+++ b/resources/styles/molecules/card/card.scss
@@ -9,7 +9,7 @@
     grid-template-areas: "icon" "headline" "content" "actions";
     grid-template-columns: auto;
     grid-template-rows: auto auto 1fr auto;
-    margin-bottom: 2rem;
+    margin-bottom: $v-space;
     z-index: 1;
 
     &__icon,
@@ -17,13 +17,13 @@
     &__content,
     &__actions {
         justify-self: center; // For IE11 (instead of justify-items)
-        padding-left: 2rem;
-        padding-right: 2rem;
+        padding-left: $h-space;
+        padding-right: $h-space;
     }
 
     &__icon {
         grid-area: icon;
-        padding-top: 2rem;
+        padding-top: $v-space;
         text-align: center; // For IE11
     }
 
@@ -52,7 +52,7 @@
         justify-content: center;
         justify-self: stretch;
         margin-top: auto;
-        padding-bottom: 2rem;
+        padding-bottom: $v-space;
 
         &.-attached {
             justify-content: stretch;

--- a/resources/styles/molecules/messaging/messaging.scss
+++ b/resources/styles/molecules/messaging/messaging.scss
@@ -25,13 +25,13 @@
     font-size: $font-size;
     line-height: $line-height;
     margin-bottom: 2rem;
-    padding: 1rem 1.618rem;
+    padding: $padding;
     display: flex;
 
     &__icon {
         height: $icon-size;
         flex-shrink: 0;
-        margin-right: 1.618rem;
+        margin-right: $h-space;
         width: $icon-size;
         @if $leading != $icon-size {
             transform: translateY(($leading - $icon-size) / 2);

--- a/resources/styles/molecules/tabs/tabs.scss
+++ b/resources/styles/molecules/tabs/tabs.scss
@@ -35,7 +35,7 @@
     &__button {
         border: none;
         background: none;
-        padding: .25rem 2rem;
+        padding: $thin-v-space $h-space;
     }
 
     &__tab.-active {

--- a/resources/styles/molecules/tiles/tiles.scss
+++ b/resources/styles/molecules/tiles/tiles.scss
@@ -17,7 +17,7 @@
     }
 
     &__tileContent {
-        padding: 2rem;
+        padding: $padding;
     }
 }
 

--- a/resources/styles/organisms/background-video/background-video.scss
+++ b/resources/styles/organisms/background-video/background-video.scss
@@ -16,7 +16,7 @@
 
     &__backdrop {
         background-color: $background;
-        padding: 2em;
+        padding: $padding;
         text-align: center;
         z-index: 2;
     }

--- a/resources/styles/organisms/modal/modal.scss
+++ b/resources/styles/organisms/modal/modal.scss
@@ -15,7 +15,7 @@
         position: relative;
         max-width: 60rem;
         background-color: $white;
-        padding: 2rem;
+        padding: $padding;
         max-height: 100vh;
     }
 

--- a/resources/styles/organisms/navigation/navigation.scss
+++ b/resources/styles/organisms/navigation/navigation.scss
@@ -12,7 +12,7 @@
 
     &__link {
         display: block;
-        padding: 1rem 1.618rem;
+        padding: $padding;
         font-weight: bold;
     }
 }
@@ -34,6 +34,6 @@
 
     &__link {
         display: block;
-        padding: .618rem 1rem;
+        padding: $thin-padding;
     }
 }


### PR DESCRIPTION
An idea I started but didn't quite finish in Beta 1 was having some variables for default padding.

Going through our existing work, I feel like we could start most projects with two default sets of padding, knowing there's no reason a developer should feel restricted to these as they develop:

* Default padding for buttons, cards, primary nav - i.e. outer padding (not to be confused with margins)
* Thin padding for breadcrumbs, input labels, and within dropdowns - i.e. inner padding.

This cleans up having hardcoded padding numbers scattered throughout Boilerplate.

I've gone back and forth, but believe it makes sense for these to be in *em* units instead of *rem* units, but curious for feedback on that.