### PR TITLE
documentation-improvements: improving documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,28 +1,30 @@
-# Contributing to Boilerplate
+# Contributing to Boilerplate Components
 
 ## Bugs, Ideas, & Requests
 
 Please [open issues](https://github.com/imarc/boilerplate-components/issues) on GitHub.
 
 * When reporting bugs, please try to provide the browser, browser version, and your platform with the report.
-* When submitting ideas or requests, be as specific as you can, as well as why it should be included within Boilerplate.
+* When submitting ideas or requests, be as specific as you can, as well as why it should be included within Boilerplate Components.
 
-As with other GitHub projects, don't submit an issue for support requests and check for existing issues.
+As with other GitHub projects:
+* check for existing issues before posting
+* don't submit an issue for support requests
 
 
 ## Creating Pull Requests
 
 Fork off of the appropriate branch:
 
-* For work on the current, stable version of Boilerplate, fork off of `master`.
-* For work on the upcoming or beta version of Boilerplate, fork off of `next`.
+* For work on the current, stable version of Boilerplate Components, fork off of `master`.
+* For work on the upcoming or beta version of Boilerplate Components, fork off of `next`.
 
-Submit a pull request and describe what your code is meant to do and why it should be included in Boilerplate; even better if you can reference articles or reasons for the change.
+Submit a pull request and describe what your code is meant to do and why it should be included in Boilerplate Components; even better if you can reference articles or reasons for the change.
 
 
 ## Follow Code Conventions
 
-Boilerplate follows [its own conventions](https://imarc-boilerplate.netlify.app/pattern-library/docs/abem.html) as closely as it can; make sure any code you submit does too. If there's areas you're not sure, fallback to Vue style guidelines and ABEM or BEM conventions, or [Imarc's Handbook.](https://handbook.imarc.com/)
+Boilerplate Components follows [its own conventions](https://imarc-boilerplate.netlify.app/pattern-library/docs/abem.html) as closely as it can; make sure any code you submit does too. If there's areas you're not sure, fallback to Vue style guidelines and ABEM or BEM conventions, or [Imarc's Handbook.](https://handbook.imarc.com/)
 
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -7,52 +7,55 @@ This is a front-end development framework that includes a curated set of convent
 * [Laravel Mix](https://laravel-mix.com/)-based **build scripts**,
 * **starter documentation** and a **pattern library** powered by [Fractal](https://fractal.build/) and [Twig](https://github.com/twigjs/twig.js).
 
-### **[View Boilerplate](https://imarc-boilerplate.netlify.app/)**
+### **[View Boilerplate Components](https://imarc-boilerplate.netlify.app/)**
 
 
-Framework, not a Library
-------------------------
+## Framework, not a Library
 
-Unlike traditional libraries, The code included within Boilerplate is *scaffolded* into your project so you can adapt it to do your needs. It adds a fractal.config.js, webpack.mix.js, as well as everything in the resources/ folder to your project. [Learn more about Boilerplate's structure.](https://imarc-boilerplate.netlify.app/pattern-library/docs/structure.html)
+Unlike traditional libraries, the code included within Boilerplate Components is *scaffolded* into your project so you can adapt it to do your needs. It adds a `fractal.config.js`, `webpack.mix.js`, as well as everything in the `resources/` folder to your project. [Learn more about Boilerplate Components' structure.](https://imarc-boilerplate.netlify.app/pattern-library/docs/structure.html)
 
-Goals
------
+## Goals
 
 See [GOALS.](.github/GOALS.md)
 
-Contributing
-------------
+## Contributing
 
 See [CONTRIBUTING.](.github/CONTRIBUTING.md)
 
+## View Boilerplate Components locally
 
-Getting Started
----------------
+To locally serve the pattern library:
 
-Within a new project, make sure you first have an existing `package.json`. If you don't have one, you can create one by running
+* `npm run fractal start` to run a local server and watch for changes
+
+To build the pattern library:
+
+* `npm run fractal build`
+
+You can customize this behavior further by editing either the `webpack.mix.js` or `fractal.config.js` files per the Laravel Mix or Fractal documentation respectively.
+
+
+## Using Boilerplate Components in a new project
+
+Within a new project, make sure you first have an existing `package.json`. If you don't have one, you can create one by running:
 
 ```
 npm init -y
 ```
 
-After that, run
+After that, run:
 
 ```
 npx imarc/boilerplate-components
 ```
 
-`npx` automatically installs Boilerplate and copies fractal.config.js, webpack.mix.js, and the resources/ folder to your project. It also adds dependencies and scripts to your package.json.
-
-
-
-Usage
------
+`npx` automatically installs Boilerplate Components and copies `fractal.config.js`, `webpack.mix.js`, and the resources/ folder to your project. It also adds dependencies and scripts to your package.json.
 
 After running `npx` above, your project will be automatically setup so you can run
 
 * `npm run dev` to run the development build (make sourcemaps, don't minify, etc.)
 * `npm run prod` to run the production build.
-* `npm run watch` to watches files for changes and automatically re-run the development build.
+* `npm run watch` to watches files for changes and automatically re-runs the development build.
 
 To locally serve the pattern library:
 
@@ -62,4 +65,4 @@ And lastly, to build the pattern library:
 
 * `npm run fractal build`
 
-You can customize this behavior further by editing either the `webpack.mix.js` or `fractal.config.js` files per the Laravel Mix or Fractal documentation respectively.
+You can customize this behavior further by editing either the `webpack.mix.js` or `fractal.config.js` files per the [Laravel Mix](https://laravel-mix.com/docs/6.0/installation) or [Fractal documentation](https://fractal.build/guide/documentation), respectively.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1240,6 +1240,8 @@
     },
     "@frctl/fractal": {
       "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@frctl/fractal/-/fractal-1.5.8.tgz",
+      "integrity": "sha512-WuWOw7hwqMUxbgFJvS91fLngEhT2w6/YTmByFpGBAuTqBWyRXt4Ctr1q1gpMwZFE0pb8c/04jNucnzxWM1yByg==",
       "requires": {
         "@frctl/core": "^0.3.1",
         "@frctl/handlebars": "^1.2.10",
@@ -1291,6 +1293,8 @@
     },
     "@frctl/twig": {
       "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@frctl/twig/-/twig-1.2.9.tgz",
+      "integrity": "sha512-Jo3YgU5pAkxFoCqbCtkO7Lg9n+FMYCbNacWL3g7Vl4Z8GcQUbq9zCYgBphYS6a8fFtIPBa8K4yX4BqE1Q7ohwA==",
       "requires": {
         "@frctl/core": "^0.3.1",
         "lodash": "^4.17.21",
@@ -3528,7 +3532,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "candlepin": {
-      "version": "1.3.4"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/candlepin/-/candlepin-1.3.4.tgz",
+      "integrity": "sha512-JvZm0XiNvXTmZiPKtJlcC80mkV7ya8Xr3yQWowta2Nmf7Pt2NsITC3px2FtlbuSF0c4+BihhWev8Tia6LGQbVA=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -4276,6 +4282,8 @@
     },
     "cross-env": {
       "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "requires": {
         "cross-spawn": "^7.0.1"
       }
@@ -5448,6 +5456,8 @@
     },
     "eslint": {
       "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
+      "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -5544,6 +5554,8 @@
     },
     "eslint-config-standard": {
       "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
+      "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -5595,6 +5607,8 @@
     },
     "eslint-plugin-import": {
       "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
@@ -5627,6 +5641,8 @@
     },
     "eslint-plugin-node": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
       "requires": {
         "eslint-plugin-es": "^3.0.0",
@@ -5653,14 +5669,20 @@
     },
     "eslint-plugin-promise": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
+      "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
       "dev": true
     },
     "eslint-plugin-standard": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
+      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
       "dev": true
     },
     "eslint-plugin-vue": {
       "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.10.0.tgz",
+      "integrity": "sha512-xdr6e4t/L2moRAeEQ9HKgge/hFq+w9v5Dj+BA54nTAzSFdUyKLiSOdZaRQjCHMY0Pk2WaQBFH9QiWG60xiC+6A==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.1.0",
@@ -5845,7 +5867,9 @@
       }
     },
     "expose-loader": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-3.0.0.tgz",
+      "integrity": "sha512-X7ncrzmiQbJHOyLwuymECHk4NYvoPFwnsINMYFaRrm4fxuxR59hV1v65bho3TpIoWieP8WZmhz6micKny8orWg=="
     },
     "express": {
       "version": "4.17.1",
@@ -6439,6 +6463,8 @@
     },
     "fractal-theme-hydrogen": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fractal-theme-hydrogen/-/fractal-theme-hydrogen-1.0.4.tgz",
+      "integrity": "sha512-0pfnpBkX6FFl1ozxqTjtKa/ph8W/sFuI9/CKDpLM6ceIzTaIvMXE4MtmPY4v34dVtfIj2oLU5nIQy4czptnong==",
       "requires": {
         "sass": "^1.32.5"
       }
@@ -7432,6 +7458,8 @@
     },
     "import-glob-loader": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/import-glob-loader/-/import-glob-loader-1.1.0.tgz",
+      "integrity": "sha1-mNhMD2Yci6n4Idndt8a23I6X7KI=",
       "requires": {
         "glob": "^5.0.13",
         "loader-utils": "^0.2.10"
@@ -8073,7 +8101,9 @@
       }
     },
     "jquery": {
-      "version": "3.6.0"
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-beautify": {
       "version": "1.13.13",
@@ -8174,6 +8204,15 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -8230,6 +8269,8 @@
     },
     "laravel-mix": {
       "version": "6.0.19",
+      "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-6.0.19.tgz",
+      "integrity": "sha512-SH//4h/bi2ff5hyBfwQ0DE0VfTkskGLU+a/l7HdmTz1F+cJdvakajziyBVRwa9U3+DyvZo9eo9Jgq1jdZWW3XQ==",
       "requires": {
         "@babel/core": "^7.12.3",
         "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
@@ -8334,6 +8375,8 @@
     },
     "laravel-mix-purgecss": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/laravel-mix-purgecss/-/laravel-mix-purgecss-6.0.0.tgz",
+      "integrity": "sha512-1OVy3xVVqvWrBTI+vQrr9qlrNKKqq3lFlWQpdJxKO2IeK8bMERkNab3fLtldyyOd5ApBuoMd81EqF4ew2N/NdA==",
       "requires": {
         "postcss-purgecss-laravel": "^2.0.0"
       }
@@ -8347,7 +8390,9 @@
       }
     },
     "lazysizes": {
-      "version": "5.3.2"
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-5.3.2.tgz",
+      "integrity": "sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg=="
     },
     "leven": {
       "version": "3.1.0",
@@ -9156,7 +9201,9 @@
       }
     },
     "mmenu-light": {
-      "version": "3.0.8"
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/mmenu-light/-/mmenu-light-3.0.8.tgz",
+      "integrity": "sha512-xwp3dk8zMUM4Zx2r3VU6vvBwDd6IxJuu6/M7hSeVH54sAnMAjqPldcn4iendcdiuuZi/m4SPaeErZKJrs6AMBw=="
     },
     "ms": {
       "version": "2.0.0",
@@ -9419,7 +9466,9 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-scss": {
-      "version": "7.0.1"
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-scss/-/normalize-scss-7.0.1.tgz",
+      "integrity": "sha512-qj16bWnYs+9/ac29IgGjySg4R5qQTp1lXfm7ApFOZNVBYFY8RZ3f8+XQNDDLHeDtI3Ba7Jj4+LuPgz9v/fne2A=="
     },
     "normalize-url": {
       "version": "3.3.0",
@@ -9428,6 +9477,8 @@
     },
     "npm": {
       "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.16.0.tgz",
+      "integrity": "sha512-UUnKcjS7qFhZT90iZY/ZWz/jwF+rS0fIohDf41T6/SRXEqut0aav+1NkL6g6GqQGpIVBzpZc75BDfpq4PhfXBg==",
       "requires": {
         "@npmcli/arborist": "^2.6.1",
         "@npmcli/ci-detect": "^1.2.0",
@@ -10360,7 +10411,9 @@
       }
     },
     "portal-vue": {
-      "version": "2.1.7"
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
+      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -13533,6 +13586,8 @@
     },
     "resolve-url-loader": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
+      "integrity": "sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==",
       "requires": {
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
@@ -13754,6 +13809,8 @@
     },
     "sass-loader": {
       "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.0.0.tgz",
+      "integrity": "sha512-LJQMyDdNdhcvoO2gJFw7KpTaioVFDeRJOuatRDUNgCIqyu4s4kgDsNofdGzAZB1zFOgo/p3fy+aR/uGXamcJBg==",
       "requires": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"
@@ -14055,7 +14112,9 @@
       }
     },
     "slick-carousel": {
-      "version": "1.8.1"
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
     },
     "smart-buffer": {
       "version": "4.1.0",
@@ -15827,10 +15886,14 @@
       }
     },
     "vue": {
-      "version": "2.6.14"
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
     },
     "vue-awesome-swiper": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vue-awesome-swiper/-/vue-awesome-swiper-4.1.1.tgz",
+      "integrity": "sha512-50um10t6N+lJaORkpwSi1wWuMmBI1sgFc9Znsi5oUykw2cO5DzLaBHcO2JNX21R+Ue4TGoIJDhhxjBHtkFrTEQ=="
     },
     "vue-eslint-parser": {
       "version": "7.6.0",
@@ -15888,6 +15951,8 @@
     },
     "vue-loader": {
       "version": "15.9.7",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.7.tgz",
+      "integrity": "sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==",
       "dev": true,
       "requires": {
         "@vue/component-compiler-utils": "^3.1.0",
@@ -15950,6 +16015,8 @@
     },
     "vue-template-compiler": {
       "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
+      "integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "homepage": "https://github.com/imarc/boilerplate#readme",
   "scripts": {
     "fractal": "fractal",
+    "fractal-start": "fractal start",
+    "fractal-build": "fractal build",
     "dev": "mix",
     "prod": "mix --production",
     "watch": "mix watch",


### PR DESCRIPTION
These edits are to make things more obvious to users – specifically Imarcians. I’ll also call out minor changes as well:

- I did not quickly know how to get BPC loaded locally in my browser. To help others, I added the script commands (`npm run fractal start`, `npm run fractal build`) under an explicit **View Boilerplate Components locally** section in the `readme.md`. I also added the script commands to `package.json` – it did not have them
- added the npx commands under a more explicit “Using Boilerplate Components in a new project” section
- changed references of _Boilerplate_ to read _Boilerplate Components_
- changed markdown to use hash-based headings in `readme.md` – no more underline dash style