### PR TITLE
banner atom's close button should not shrink

### DIFF
--- a/resources/styles/atoms/banner/banner.scss
+++ b/resources/styles/atoms/banner/banner.scss
@@ -1,21 +1,26 @@
 .banner {
     background-color: $info;
     color: blackwhite($info);
-    padding: $padding;
+    padding: $v-space 0;
 
     &__container {
         display: flex;
         justify-content: space-between;
-        align-items: center;
     }
 
     &__dismiss {
+        background-color: transparent;
         border: 0;
         cursor: pointer;
-        padding: 0;
-        width: 1.5rem;
+        fill: none;
+        flex-shrink: 0;
         height: 1.5rem;
-        background-color: transparent;
+        padding: 0;
+        stroke: currentColor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 1.5;
+        width: 1.5rem;
     }
 
 }

--- a/resources/styles/atoms/banner/banner.twig
+++ b/resources/styles/atoms/banner/banner.twig
@@ -1,10 +1,10 @@
 <div class="banner">
     <div class="banner__container container">
         <div class="banner__messsage">
-            Sit quisquam error ipsum atque odit ex At eum eius autem perspiciatis sit! Sint ab!
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ad eius nostrum blanditiis modi cupiditate repudiandae, delectus sequi sunt, officia quia fuga ut nobis.
         </div>
-        <button class="banner__dismiss">
-            <svg xmlns="http://www.w3.org/2000/svg" class="banner__dismissIcon" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <button class="banner__dismiss" aria-label="Close">
+            <svg xmlns="http://www.w3.org/2000/svg" class="banner__dismissIcon" viewBox="0 0 24 24">
                 <line x1="18" y1="6" x2="6" y2="18" />
                 <line x1="6" y1="6" x2="18" y2="18" />
             </svg>


### PR DESCRIPTION
- ensure that the dismiss button will not shrink when more text is added to banner
- align it to top – I did not carry over the messaging icon stuff here, mostly because it looked ok without it, and thinking about it made my head spin with bigger things I might want to address
- bring SVG attributes such as `stroke`, `stroke-linecap`, `stroke-linejoin`, `stroke-width` to scss
- I also modified the padding of this atom but I think we need to think more about how these should be padded out