### PR TITLE
rename container's $padding argument to $padding-x

### DIFF
--- a/resources/styles/utilities/container/README.md
+++ b/resources/styles/utilities/container/README.md
@@ -1,1 +1,1 @@
-The container mixin and class limit content to the max width configured by the `$container` variable, leading one `$gutter` width of padding on either side.
+The container mixin and class limit content to the max width configured by the `$container` variable, using the `$gutter` variable for left and right padding.

--- a/resources/styles/utilities/container/README.md
+++ b/resources/styles/utilities/container/README.md
@@ -1,1 +1,1 @@
-The container mixin and class limit content to the max width configured by the `$container` variable, using the `$gutter` variable for left and right padding.
+The container mixin and class limit content to the max width configured by the `$container` variable, using the `$gutter` variable by default for left and right padding.

--- a/resources/styles/utilities/container/container.scss
+++ b/resources/styles/utilities/container/container.scss
@@ -1,12 +1,12 @@
 ///
 /// container mixin
 ///
-@mixin container($max-width: $container, $padding: $gutter) {
+@mixin container($max-width: $container, $padding-x: $gutter) {
     margin-left: auto;
     margin-right: auto;
     max-width: $max-width;
-    padding-left: $padding;
-    padding-right: $padding;
+    padding-left: $padding-x;
+    padding-right: $padding-x;
     position: relative;
 }
 

--- a/resources/styles/utilities/container/container.scss
+++ b/resources/styles/utilities/container/container.scss
@@ -1,12 +1,12 @@
 ///
 /// container mixin
 ///
-@mixin container($max-width: $container, $padding-x: $gutter) {
+@mixin container($max-width: $container, $h-padding: $gutter) {
     margin-left: auto;
     margin-right: auto;
     max-width: $max-width;
-    padding-left: $padding-x;
-    padding-right: $padding-x;
+    padding-left: $h-padding;
+    padding-right: $h-padding;
     position: relative;
 }
 


### PR DESCRIPTION
At first, this confused me as the `_variables.scss` file also has a `$padding` variable. IMO, `$padding-x` is clearer and could reduce others' potential confusion. I also modified the notes for this.