### PR TITLE
rework BpDropdown's use of focusout

### DIFF
--- a/resources/styles/atoms/dropdown/BpDropdown.vue
+++ b/resources/styles/atoms/dropdown/BpDropdown.vue
@@ -4,7 +4,7 @@
             ref="dropdown"
             class="dropdown"
             :class="{'-open': expanded}"
-            v-on="{ mouseleave, focusout, mouseover }"
+            v-on="{ mouseleave, focusout, mouseover, mouseup, mousedown }"
         >
             <a
                 ref="link"
@@ -85,18 +85,33 @@ export default {
         timer: new Timer(),
         expanded: false,
     }),
+
+    destroyed () {
+        removeExternalClickListener(this.externalClick)
+    },
     methods: {
         mouseleave (evt) {
             if (this.hoverable) {
                 this.timer.start(() => this.close(false), this.delay)
             }
         },
+
+        mouseup (evt) {
+            console.log('mouseup', evt)
+        },
+
+        mousedown (evt) {
+            console.log('mousedown', evt)
+        },
+
         focusout (evt) {
-            if (this.expanded && !this.$el.contains(evt.relatedTarget)) {
+            console.log('focusout', evt)
+            if (evt.relatedTarget && this.expanded && !this.$el.contains(evt.relatedTarget)) {
                 this.close(false)
             }
         },
         click (evt) {
+            console.log('click', evt)
             if (this.expanded) {
                 this.close()
             } else {
@@ -112,10 +127,18 @@ export default {
             }
         },
 
+        externalClick (evt) {
+            console.log('externalClick', evt)
+            if (evt.srcElement && !this.$el.contains(evt.srcElement)) {
+                this.close(false)
+            }
+        },
+
         open () {
             this.$emit('open')
             this.timer.clear()
             this.expanded = true
+            addEventListener('click', this.externalClick)
         },
         close (refocus = true) {
             this.$emit('close')
@@ -124,6 +147,7 @@ export default {
             if (refocus) {
                 this.$refs.link.focus()
             }
+            removeEventListener('click', this.externalClick)
         },
     },
 }

--- a/resources/styles/atoms/dropdown/dropdown--large.twig
+++ b/resources/styles/atoms/dropdown/dropdown--large.twig
@@ -46,5 +46,3 @@
         </div>
     </bp-directional>
 </bp-dropdown>
-
-<a href="#">example</a>

--- a/resources/styles/atoms/dropdown/dropdown--large.twig
+++ b/resources/styles/atoms/dropdown/dropdown--large.twig
@@ -1,0 +1,50 @@
+<bp-dropdown href="/about" label="Our Company" id="js-about" {% if class %}class="{{ class }}"{% endif %}>
+    <bp-directional>
+        <div class="container linkGroups">
+            <div class="linkGroup">
+                <div class="linkGroup__heading">Seacoast</div>
+                <ul class="linkGroup__list -wide">
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Bar Harbor</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Camden</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Castine</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Damariscotta</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Kennebunkport</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Old Orchard Beach</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Portland</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Rockland</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Stonington</a></li>
+                </ul>
+            </div>
+            <div class="linkGroup">
+                <div class="linkGroup__heading">Parks</div>
+                <ul class="linkGroup__list">
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Acadia</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Baxter</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Camden Hills</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Popham Beach</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Quoddy Head</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Reid</a></li>
+                </ul>
+            </div>
+            <div class="linkGroup">
+                <div class="linkGroup__heading">Activities</div>
+                <ul class="linkGroup__list">
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Agricultural Attractions</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Arts &amp; Culture</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Camping</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Fishing</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Guide Services</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Hiking &amp; Climbing</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Hunting</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Lighthouses &amp; Sightseeing</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Shopping</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Spas, Health &amp; Wellness</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Wildlife Watching</a></li>
+                    <li class="linkGroup__item"><a class="linkGroup__link" href="#">Winter Activities</a></li>
+                </ul>
+            </div>
+        </div>
+    </bp-directional>
+</bp-dropdown>
+
+<a href="#">example</a>


### PR DESCRIPTION
Because focusout events don't reliably have a relatedTarget, this add a global listener while the dropdown is open to handle clicking outside of the dropdown properly.