### PR TITLE
Crawlbar layer actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imarc-boilerplate",
-  "version": "5.0.12",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "imarc-boilerplate",
-      "version": "5.0.12",
+      "version": "5.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@frctl/fractal": "^1.5.4",

--- a/resources/styles/examples/00-homepage.twig
+++ b/resources/styles/examples/00-homepage.twig
@@ -22,6 +22,7 @@
             </div>
             <div class="layer__actions">
                 <a class="layer__action button -primary" href="#">Learn More</a>
+                <a class="layer__action button -outline -secondary" href="#">Lorem Ipsum Amat</a>
             </div>
         </div>
     </section>

--- a/resources/styles/organisms/layer/layer--callToAction.scss
+++ b/resources/styles/organisms/layer/layer--callToAction.scss
@@ -4,10 +4,5 @@
         background-color: $primary;
         color: $white;
         text-align: center;
-
-        .layer__action {
-            @include button($white, $primary);
-            font-weight: bold;
-        }
     }
 }

--- a/resources/styles/organisms/layer/layer--callToAction.twig
+++ b/resources/styles/organisms/layer/layer--callToAction.twig
@@ -7,8 +7,9 @@
         <div class="layer__content">
             <p>Consectetur alias placeat doloremque placeat asperiores Reprehenderit corporis atque amet sunt ullam assumenda delectus.</p>
         </div>
-        <div class="layer__actions">
+        <div class="layer__actions -centered">
             <a class="layer__action button -outline" href="#">Sign Up Now</a>
+            <a class="layer__action button -secondary" href="#">Lorem Ipsum</a>
         </div>
     </div>
 </section>

--- a/resources/styles/organisms/layer/layer.scss
+++ b/resources/styles/organisms/layer/layer.scss
@@ -2,6 +2,7 @@
     align-items: center;
     display: grid;
     grid-template: "stack";
+    grid-template-columns: minmax(0, 1fr);
 
     &__container {
         padding-top: 4rem;
@@ -51,14 +52,12 @@
     }
 
     &__introduction {
-
         &.-emphasized {
             font-size: 1.125rem;
         }
     }
 
     &__item {
-
         &.-sidebar {
             background-color: $blue-200;
             padding: $padding;
@@ -70,10 +69,20 @@
     }
 
     &__actions {
+        align-items: center;
         display: flex;
-        justify-content: center;
+        flex-wrap: wrap;
+        gap: $h-space;
+
+        &.-centered {
+            justify-content: center;
+        }
     }
 
+    &__action {
+        @include button($white, $primary);
+        font-weight: bold;
+    }
 
     &.-dark {
         background-color: $blue-900;

--- a/resources/styles/organisms/site-footer/site-footer.scss
+++ b/resources/styles/organisms/site-footer/site-footer.scss
@@ -8,25 +8,57 @@
     }
 
     &__container {
-        align-items: flex-start;
+        align-items: center;
         display: flex;
+        flex-direction: column;
         justify-content: space-between;
 
         > * {
             flex: 1;
         }
+
+        @include at(lg) {
+            align-items: flex-start;
+            flex-direction: row;
+        }
     }
 
     &__links {
+        display: block;
         flex: 2;
+        gap: $h-space;
+        width: 100%;
+
+        @include at(lg) {
+            display: flex;
+        }
+
+        > * {
+            width: auto;
+        }
+    }
+
+    &__linkGroup {
+        text-align: center;
+
+        & + & {
+            margin-left: 0;
+        }
+
+        @include at(lg) {
+            text-align: left;
+        }
     }
 
     &__brand {
         align-items: center;
         color: $primary;
         display: flex;
-        margin-right: 2rem;
         padding: $thin-v-space 0;
+
+        @include at(lg) {
+            margin-right: 2rem;
+        }
     }
 
     &__logo {

--- a/resources/styles/organisms/site-footer/site-footer.twig
+++ b/resources/styles/organisms/site-footer/site-footer.twig
@@ -20,7 +20,7 @@
         </a>
 
         <div class="siteFooter__links linkGroups">
-            <div class="linkGroup">
+            <div class="siteFooter__linkGroup linkGroup">
                 <div class="linkGroup__heading">Maine</div>
                 <ul class="linkGroup__list">
                     <li class="linkGroup__item"><a class="linkGroup__link" href="#">Seacoast</a></li>
@@ -28,7 +28,7 @@
                     <li class="linkGroup__item"><a class="linkGroup__link" href="#">Activities</a></li>
                 </ul>
             </div>
-            <div class="linkGroup">
+            <div class="siteFooter__linkGroup linkGroup">
                 <div class="linkGroup__heading">Massachusetts</div>
                 <ul class="linkGroup__list -span-2">
                     <li class="linkGroup__item"><a class="linkGroup__link" href="#">Boston</a></li>
@@ -41,7 +41,7 @@
                     <li class="linkGroup__item"><a class="linkGroup__link" href="#">Provincetown</a></li>
                 </ul>
             </div>
-            <div class="linkGroup">
+            <div class="siteFooter__linkGroup linkGroup">
                 <div class="linkGroup__heading">New Hampshire</div>
                 <ul class="linkGroup__list">
                     <li class="linkGroup__item"><a class="linkGroup__link" href="#">Towns</a></li>


### PR DESCRIPTION
moved layer__actions out of the layer—calltoAction variant as we use these in all sorts of layers, not just a dedicated variant

after moving it, modified the styles so it doesn’t automatically center, and so we can account for more than one button, and have them spaced out properly, wrapping it they need to (especially on mobile) – these 2 buttons can now be seen on the homepage and on layer—calltoAction

layer__actions also needed a modifier so we can center them if we want (which I added into layer—callToAction.twig)

there was a crawler appearing on the homepage because of two issues: 
- a grid blowout on .layer….seems this needs some sort of width so it doesn’t cause issues: see https://css-tricks.com/preventing-a-grid-blowout/
- footer’s contents were too wide

i’d like to re-do the footer completely at some point but it doesn’t cause crawlbar anymore
