### PR TITLE
Fixed eslint issue with undefined vue compile-time methods.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imarc-boilerplate",
-  "version": "6.0.0",
+  "version": "6.0.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "imarc-boilerplate",
-      "version": "6.0.0",
+      "version": "6.0.0-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@frctl/fractal": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "eslintConfig": {
     "env": {
       "browser": true,
-      "es6": true
+      "es6": true,
+      "vue/setup-compiler-macros": true
     },
     "extends": [
       "plugin:vue/vue3-recommended",


### PR DESCRIPTION
@khamer Just adding this little guy. Was still getting eslint warnings in VSCode.